### PR TITLE
Add strong pk detection

### DIFF
--- a/.github/workflows/scala-test.yml
+++ b/.github/workflows/scala-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 jobs:
   scalafmt-lint:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ This tool supports some heuristics for determining a good primary key candidate.
 Stricter checking, with use of these heuristics, can be enabled by passing a `--strict`
 flag during execution. Then, it is assured that
 
-- the values of a PK column only ever increase
-- the column contains no duplicate values
+- the values of a PK column only ever increase over time
 - the column name indicates a PK column
+
+in addition to the existing check which ensures that
+
+- the column values are unique over time
 
 This can increase the accuracy of the primary key detection.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Afterwards, a new .xes log file will be generated next to the input log file.
 The `artifacts` folder contains an example redo log, as well as a more verbose one, 
 and an overview of the state the example database was in after process execution.
 
+## Strong Primary Key Detection
+
+This tool supports some heuristics for determining a good primary key candidate.
+Stricter checking, with use of these heuristics, can be enabled by passing a `--strict`
+flag during execution. Then, it is assured that
+
+- the values of a PK column only ever increase
+- the column contains no duplicate values
+- the column name indicates a PK column
+
+This can increase the accuracy of the primary key detection.
+
 ## Requirements
 
 In order for the tool to run, a working installation of `Java 11` is required,

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For development, we recommend using `IntelliJ IDEA 2020.2` or newer.
 
 The data for evaluating this implementation was generated via 
 [this](https://github.com/tom-lichtenstein/process-simulator) tool. It is designed to work with
-a running Oracle DB 19c EE, which can be dowloaded [here](https://www.oracle.com/database/technologies/oracle-database-software-downloads.html#19c).
+a running Oracle DB 19c EE, which can be downloaded [here](https://www.oracle.com/database/technologies/oracle-database-software-downloads.html#19c).
 
 [This article](https://docs.oracle.com/en/database/oracle/oracle-database/18/sutil/oracle-logminer-utility.html#GUID-3417B738-374C-4EE3-B15C-3A66E01AE2B5)
 provides information on how to extract the REDO log file. The database should be configured to archive the redo log prior to the process simulation. The output should be stored as a plain text file next to the cli tool.

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / scalaVersion := "2.12.11"
-ThisBuild / version := "0.1.1"
+ThisBuild / version := "0.2.0"
 ThisBuild / organization := "de.hpi"
 ThisBuild / organizationName := "bpt"
 

--- a/src/main/scala/cli/Main.scala
+++ b/src/main/scala/cli/Main.scala
@@ -4,9 +4,9 @@ import java.nio.file.Path
 
 import cats.implicits._
 import com.monovore.decline._
+import parser.RootClass
 import parser.file.{EventExtractor, FileParser}
 import parser.trace.TraceIDParser
-import parser.RootClass
 import parser.trace.TraceIDParser.generateXMLLog
 import schema.SchemaExtractor
 
@@ -25,10 +25,24 @@ object Main
           .flag("verbose", help = "Print detailed information the console.")
           .orFalse
 
-        (filePath, verboseOpt).mapN {
-          (pathParam, verboseParam) =>
+        val strongPKOpt = Opts
+          .flag(
+            "strict",
+            help =
+              "Only allow strong Primary Key candidates by checking whether " +
+                "the column names indicate a primary key and the values only ever increase "
+          )
+          .orFalse
+
+        (filePath, verboseOpt, strongPKOpt).mapN {
+          (pathParam, verboseParam, strongPKParam) =>
             implicit val verbose: Boolean = verboseParam
             implicit val path: Path = pathParam
+
+            // determine strictness of PK checking
+            cli.strictPrimaryKeyChecking = strongPKParam
+            if (verbose && strongPKParam)
+              println("Strong PK Checking has been enabled!")
 
             printPath()
             // todo: make block separator a parameter

--- a/src/main/scala/cli/package.scala
+++ b/src/main/scala/cli/package.scala
@@ -4,6 +4,9 @@ import parser.{ExtractedLogEntry, LogEntryWithRedoStatement}
 import schema.DatabaseSchema
 
 package object cli {
+
+  var strictPrimaryKeyChecking: Boolean = false
+
   def printEntries(
       logEntries: Seq[ExtractedLogEntry]
   )(implicit path: Path, verbose: Boolean): Unit = {

--- a/src/main/scala/parser/file/EventExtractor.scala
+++ b/src/main/scala/parser/file/EventExtractor.scala
@@ -1,10 +1,6 @@
 package parser.file
 
-import parser.ParsedStatement.{
-  DeleteStatement,
-  InsertStatement,
-  UpdateStatement
-}
+import parser.ParsedStatement.{DeleteStatement, InsertStatement, UpdateStatement}
 import parser.{LogEntryWithRedoStatement, ParsedStatement}
 
 import scala.collection.mutable

--- a/src/main/scala/parser/file/EventExtractor.scala
+++ b/src/main/scala/parser/file/EventExtractor.scala
@@ -1,6 +1,10 @@
 package parser.file
 
-import parser.ParsedStatement.{DeleteStatement, InsertStatement, UpdateStatement}
+import parser.ParsedStatement.{
+  DeleteStatement,
+  InsertStatement,
+  UpdateStatement
+}
 import parser.{LogEntryWithRedoStatement, ParsedStatement}
 
 import scala.collection.mutable

--- a/src/main/scala/parser/relations/RelationsExtractor.scala
+++ b/src/main/scala/parser/relations/RelationsExtractor.scala
@@ -200,7 +200,7 @@ object RelationsExtractor {
       .flatMap(col => {
         col.isSubsetOf = col.isSubsetOf
           .filter(_.table.name.equalsIgnoreCase(relation.leftTable.name))
-          .filter(_.isPrimaryKey)
+          .filter(_.isPrimaryKeyCandidate)
         val columnPairs =
           col.isSubsetOf.map(referencedColumn =>
             ColumnRelation(referencedColumn, col)
@@ -222,7 +222,7 @@ object RelationsExtractor {
       .flatMap(col => {
         col.isSubsetOf = col.isSubsetOf
           .filter(_.table.name.equalsIgnoreCase(relation.rightTable.name))
-          .filter(_.isPrimaryKey)
+          .filter(_.isPrimaryKeyCandidate)
         val columnPairs =
           col.isSubsetOf.map(referencedColumn =>
             ColumnRelation(col, referencedColumn)

--- a/src/main/scala/schema/Column.scala
+++ b/src/main/scala/schema/Column.scala
@@ -81,7 +81,7 @@ class Column(
   private def isColumnNamePotentiallyPrimaryKey = {
     columnName.matches("(?i:.*id)") ||
     columnName.matches("(?i:.*nr)") ||
-    columnName.matches("(?i:.*name)") ||
+    columnName.matches("(?i:.*key)") ||
     columnName.matches("(?i:.*no)")
 
   }

--- a/src/main/scala/schema/Column.scala
+++ b/src/main/scala/schema/Column.scala
@@ -6,21 +6,31 @@ class Column(
     columnName: String,
     columnTable: Table,
     columnIsPrimaryKey: Boolean,
+    areColumnValuesIncreasing: Boolean,
     columnIsSubsetOf: Seq[Column],
     columnValues: mutable.HashMap[String, String] // ROWID -> VALUE
 ) {
   val name: String = columnName
   val table: Table = columnTable
-  var isPrimaryKey: Boolean = columnIsPrimaryKey
+  var canBePrimaryKey: Boolean = columnIsPrimaryKey
+  var areValuesIncreasing: Boolean = areColumnValuesIncreasing
+
   var isSubsetOf: Seq[Column] = columnIsSubsetOf
   val values: mutable.HashMap[String, String] = columnValues
 
   override def clone(): Column = {
-    new Column(name, table, isPrimaryKey, isSubsetOf, values.clone())
+    new Column(
+      name,
+      table,
+      canBePrimaryKey,
+      areValuesIncreasing,
+      isSubsetOf,
+      values.clone()
+    )
   }
 
   override def toString: String = {
-    val primaryKey = if (isPrimaryKey) {
+    val primaryKey = if (isPrimaryKeyCandidate) {
       " (PRIMARY KEY)"
     } else {
       ""
@@ -34,4 +44,46 @@ class Column(
     }
     s"$name$primaryKey $foreignKeyString"
   }
+
+  // determines how a primary key can be determined:
+  // strict or lenient
+  def isPrimaryKeyCandidate: Boolean = {
+    if (cli.strictPrimaryKeyChecking) {
+      isStrongPrimaryKey
+    } else {
+      canBePrimaryKey
+    }
+  }
+
+  // verify whether up until now all values have been increasing
+  // ==> good indicator for a primary key
+  def verifyIncreasingValuesOnChange(): Unit = {
+    // if values have not been increasing before, we don't need to check again
+    if (!areValuesIncreasing) return;
+
+    val valuesAreMonotonous = values.values.toSeq.sliding(2).forall {
+      case x :: y :: _ => x < y
+      case _           => true
+    }
+    if (valuesAreMonotonous && areValuesIncreasing) {
+      areValuesIncreasing = true
+    } else {
+      areValuesIncreasing = false
+    }
+  }
+
+  // indicates whether the values indicate a strong primary key and the values are always increasing
+  private def isStrongPrimaryKey: Boolean = {
+    canBePrimaryKey && areValuesIncreasing && isColumnNamePotentiallyPrimaryKey
+  }
+
+  // verify whether the name indicates a good primary key candidate
+  private def isColumnNamePotentiallyPrimaryKey = {
+    columnName.matches("(?i:.*id)") ||
+    columnName.matches("(?i:.*nr)") ||
+    columnName.matches("(?i:.*name)") ||
+    columnName.matches("(?i:.*no)")
+
+  }
+
 }

--- a/src/main/scala/schema/SchemaDeriver.scala
+++ b/src/main/scala/schema/SchemaDeriver.scala
@@ -28,7 +28,7 @@ object SchemaDeriver {
   private def checkForPrimaryKeyDuplicates(column: Column): Unit = {
     val values = column.values.values.toList
     if (values.size > values.distinct.size) {
-      column.isPrimaryKey = false
+      column.canBePrimaryKey = false
     }
   }
 

--- a/src/main/scala/schema/SchemaExtractor.scala
+++ b/src/main/scala/schema/SchemaExtractor.scala
@@ -74,11 +74,13 @@ object SchemaExtractor {
           attribute,
           table,
           columnIsPrimaryKey = true,
+          areColumnValuesIncreasing = true,
           Seq(),
           mutable.HashMap(rowID -> value)
         ))
       } else {
         table.columns(attribute).values += (rowID -> value)
+        table.columns(attribute).verifyIncreasingValuesOnChange()
       }
     })
   }
@@ -96,12 +98,16 @@ object SchemaExtractor {
         statement.affectedAttribute,
         table,
         columnIsPrimaryKey = true,
+        areColumnValuesIncreasing = true,
         Seq(),
         mutable.HashMap(rowID -> statement.newAttributeValue)
       ))
     } else {
       table.columns(statement.affectedAttribute).values(rowID) =
         statement.newAttributeValue
+      table
+        .columns(statement.affectedAttribute)
+        .verifyIncreasingValuesOnChange()
     }
   }
 
@@ -122,6 +128,7 @@ object SchemaExtractor {
             attribute,
             table,
             columnIsPrimaryKey = true,
+            areColumnValuesIncreasing = true,
             Seq(),
             mutable.HashMap[String, String]()
           ))

--- a/src/main/scala/schema/Table.scala
+++ b/src/main/scala/schema/Table.scala
@@ -16,11 +16,13 @@ class Table(
         columnId,
         columnTable = this,
         columnIsPrimaryKey = true,
+        areColumnValuesIncreasing = true,
         columnIsSubsetOf = Seq(),
         columnValues = mutable.HashMap(rowId -> value)
       ))
     } else {
       columns(columnId).values += (rowId -> value)
+      columns(columnId).verifyIncreasingValuesOnChange()
     }
   }
 


### PR DESCRIPTION
This implements the option to optionally toggle stronger public key candidate detection.
It takes into account 
- the values of a column (which should only be ever increasing) over time
- the column name (does it indicate a primary key column)

 in addition to the value uniqueness over time, which is already checked.
This feature can be toggled by a `--strict` flag.