### PR TITLE
Intoduce more graceful failures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / scalaVersion := "2.12.11"
-ThisBuild / version := "0.2.1"
+ThisBuild / version := "0.2.2"
 ThisBuild / organization := "de.hpi"
 ThisBuild / organizationName := "bpt"
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ ThisBuild / version := "0.2.1"
 ThisBuild / organization := "de.hpi"
 ThisBuild / organizationName := "bpt"
 
+trapExit := false
+
 lazy val root = (project in file("."))
   .settings(
     name := "redo-log-parser",

--- a/src/main/scala/cli/Main.scala
+++ b/src/main/scala/cli/Main.scala
@@ -88,7 +88,7 @@ object Main
 
             printDatabaseSchema(databaseSchema)
 
-            val rootClass = getRootClassInput(databaseSchema).get
+            val rootClass = getRootClassInput(databaseSchema)
 
             println("\nStart creating traces from the redo log ...")
 

--- a/src/main/scala/cli/Main.scala
+++ b/src/main/scala/cli/Main.scala
@@ -1,14 +1,13 @@
 package cli
 
-import java.nio.file.Path
-
 import cats.implicits._
 import com.monovore.decline._
-import parser.RootClass
 import parser.file.{EventExtractor, FileParser}
 import parser.trace.TraceIDParser
 import parser.trace.TraceIDParser.generateXMLLog
 import schema.SchemaExtractor
+
+import java.nio.file.Path
 
 /**
   * The main object of the CLI tool - it is used to run the tool.
@@ -79,9 +78,7 @@ object Main
 
             printDatabaseSchema(databaseSchema)
 
-            val rootClassInput =
-              scala.io.StdIn.readLine("\nPlease enter a root class:")
-            val rootClass = RootClass(rootClassInput)
+            val rootClass = getRootClassInput(databaseSchema).get
 
             println("\nStart creating traces from the redo log ...")
 

--- a/src/main/scala/cli/Main.scala
+++ b/src/main/scala/cli/Main.scala
@@ -7,6 +7,7 @@ import parser.trace.TraceIDParser
 import parser.trace.TraceIDParser.generateXMLLog
 import schema.SchemaExtractor
 
+import java.io.FileNotFoundException
 import java.nio.file.Path
 
 /**
@@ -60,8 +61,17 @@ object Main
             // todo: make date time format a parameter
 
             println("Reading and parsing redo log...")
+            var logEntries: Seq[parser.ExtractedLogEntry] = null
+            try {
+              logEntries = FileParser.getAndParseLogFile(path)
+            } catch {
+              case _: FileNotFoundException =>
+                println(
+                  "The file you provided could not be found. Please ensure that the path to the redo log is correct, and that the log exists."
+                )
+                System.exit(1)
 
-            val logEntries = FileParser.getAndParseLogFile(path)
+            }
             printEntries(logEntries)
             val parsedLogEntries = FileParser.parseLogEntries(logEntries)
             printParsedLogEntries(parsedLogEntries)

--- a/src/main/scala/cli/package.scala
+++ b/src/main/scala/cli/package.scala
@@ -3,7 +3,6 @@ import schema.DatabaseSchema
 
 import java.nio.file.Path
 import scala.annotation.tailrec
-import scala.util.{Success, Try}
 
 /**
   * A companion object holding additional print methods for the CLI tool,
@@ -67,12 +66,12 @@ package object cli {
   }
 
   @tailrec
-  def getRootClassInput(schema: DatabaseSchema): Try[RootClass] = {
+  def getRootClassInput(schema: DatabaseSchema): RootClass = {
     val rootClassInput =
       scala.io.StdIn.readLine("\nPlease enter a root class:")
     val rootClass = RootClass(rootClassInput)
     if (schema.keySet.contains(rootClass.tableID)) {
-      Success(rootClass)
+      rootClass
     } else {
       println(
         s"\nThe class $rootClassInput you entered does not seem to exist. Please try again!"

--- a/src/main/scala/cli/package.scala
+++ b/src/main/scala/cli/package.scala
@@ -1,7 +1,9 @@
-import java.nio.file.Path
-
-import parser.{ExtractedLogEntry, LogEntryWithRedoStatement}
+import parser.{ExtractedLogEntry, LogEntryWithRedoStatement, RootClass}
 import schema.DatabaseSchema
+
+import java.nio.file.Path
+import scala.annotation.tailrec
+import scala.util.{Success, Try}
 
 /**
   * A companion object holding additional print methods for the CLI tool,
@@ -62,5 +64,20 @@ package object cli {
   def printPath()(implicit path: Path, verbose: Boolean): Unit = {
     if (verbose)
       println(s"\n\nGetting log file from ${path.toAbsolutePath.toString}")
+  }
+
+  @tailrec
+  def getRootClassInput(schema: DatabaseSchema): Try[RootClass] = {
+    val rootClassInput =
+      scala.io.StdIn.readLine("\nPlease enter a root class:")
+    val rootClass = RootClass(rootClassInput)
+    if (schema.keySet.contains(rootClass.tableID)) {
+      Success(rootClass)
+    } else {
+      println(
+        s"\nThe class $rootClassInput you entered does not seem to exist. Please try again!"
+      )
+      getRootClassInput(schema)
+    }
   }
 }


### PR DESCRIPTION
This MR introduces

- a more graceful exit of the program when the log file can't be read :eyeglasses: 
- a way of asking for re-entry of the root class if it can't be found in the schema (i.e., was entered incorrectly) :mag: 